### PR TITLE
Split classpath by File.pathSeparator

### DIFF
--- a/scalajs-plugin/src/main/groovy/com/github/gtache/tasks/CompileJSTask.groovy
+++ b/scalajs-plugin/src/main/groovy/com/github/gtache/tasks/CompileJSTask.groovy
@@ -80,7 +80,7 @@ public class CompileJSTask extends DefaultTask {
      * @return The configured options
      */
     private def Scalajsld.Options parseOptions() {
-        final def classpath = project.files(project.buildscript.configurations.getByName('classpath').asPath.split(';'))
+        final def classpath = project.files(project.buildscript.configurations.getByName('classpath').asPath.split(File.pathSeparator))
         final def cp = classpath + project.configurations.runtime + project.sourceSets.main.runtimeClasspath
         def options = Scalajsld.defaultOptions().withClasspath(
                 JavaConverters.asScalaSetConverter(cp.getFiles()).asScala().toSet().toSeq())


### PR DESCRIPTION
Otherwise the plugin is platform dependent. It doesn't work on Unixes, after this fix it will! :)
