### PR TITLE
Get classpath separator from system

### DIFF
--- a/scalajs-plugin/src/main/groovy/com/github/gtache/CompileJS.groovy
+++ b/scalajs-plugin/src/main/groovy/com/github/gtache/CompileJS.groovy
@@ -49,7 +49,8 @@ public class CompileJSTask extends DefaultTask {
      */
     @TaskAction
     def exec() {
-        FileCollection classpath = project.files(project.buildscript.configurations.getByName('classpath').asPath.split(';'))
+        String separator = System.getProperty("path.separator")
+        FileCollection classpath = project.files(project.buildscript.configurations.getByName('classpath').asPath.split(separator))
         FileCollection cp = classpath + project.configurations.runtime + project.sourceSets.main.runtimeClasspath
         Scalajsld.Options curOptions = Scalajsld.options()
         Scalajsld.Options options = curOptions.withOutput(destFile).withClasspath(


### PR DESCRIPTION
Classpath separator on OSX is ':' instead of ';'. This change gets the path separator from the system to ensure cross-platform compatibility.
